### PR TITLE
Fix build with latest hyper and stable rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,6 @@ hyper = { git = "https://github.com/hyperium/hyper" }
 error-chain = "0.10.0"
 serde_json = "0.9.10"
 futures = "0.1.13"
+
+[dev-dependencies]
 tokio-core = "0.1.6"

--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ pub struct Response {
 
 ## Requirements
 You need `tokio_core` in order to use this library, as the construction of `IpApi` requires an instance of `Handle`.
+You need Rust 1.26 or later for `impl Trait`.

--- a/README.md
+++ b/README.md
@@ -24,5 +24,4 @@ pub struct Response {
 ```
 
 ## Requirements
-You need `tokio_core` in order to use this library, as the construction of `IpApi` requires an instance of `Handle`.
 You need Rust 1.26 or later for `impl Trait`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(conservative_impl_trait)]
-
 extern crate hyper;
 #[macro_use]
 extern crate error_chain;
@@ -7,7 +5,6 @@ extern crate serde_json;
 extern crate futures;
 extern crate tokio_core;
 
-use tokio_core::reactor::Handle;
 use std::net::IpAddr;
 use futures::Future;
 use futures::Stream;
@@ -58,9 +55,9 @@ pub struct IpApi {
 }
 
 impl IpApi {
-    pub fn new(handle: Handle) -> Self {
+    pub fn new() -> Self {
         IpApi {
-            client: Client::new(&handle),
+            client: Client::new(),
         }
     }
 
@@ -73,7 +70,7 @@ impl IpApi {
 
         self.client.get(uri)
             .and_then(|response| {
-                response.body()
+                response.into_body()
                     .map(|chunk| chunk.to_vec())
                     .collect()
                     .map(|vec| vec.concat())
@@ -157,19 +154,18 @@ mod tests {
             country: Some(NameAndCode { name: "United States".to_owned(), code: "US".to_owned() }),
             region: Some(NameAndCode { name: "California".to_owned(), code: "CA".to_owned() }),
             city: Some("Mountain View".to_owned()),
-            zip: Some("94035".to_owned()),
-            location: Some(Coordinates { latitude: 37.386, longitude: -122.0838 }),
+            zip: Some("".to_owned()),
+            location: Some(Coordinates { latitude: 37.4229, longitude: -122.085 }),
             timezone: Some("America/Los_Angeles".to_owned()),
             isp: Some("Google".to_owned()),
             organization: Some("Google".to_owned()),
-            autonomous_system: Some("AS15169 Google Inc.".to_owned()),
+            autonomous_system: Some("AS15169 Google LLC".to_owned()),
             reverse: None,
             mobile: false,
             proxy: false
         };
         let mut core = Core::new().unwrap();
-        let handle = core.handle();
-        let ip_api = IpApi::new(handle);
+        let ip_api = IpApi::new();
         let future = ip_api.request(Some(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))))
             .map(|result| {
                 assert_eq!(result, expected);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@ extern crate hyper;
 extern crate error_chain;
 extern crate serde_json;
 extern crate futures;
-extern crate tokio_core;
 
 use std::net::IpAddr;
 use futures::Future;
@@ -143,9 +142,11 @@ fn get_string(json: &Value, index: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    extern crate tokio_core;
+
     use super::*;
     use std::net::Ipv4Addr;
-    use tokio_core::reactor::Core;
+    use tests::tokio_core::reactor::Core;
 
     #[test]
     fn it_works() {


### PR DESCRIPTION
hyper::Client does not need Core.handle now

adjusted test to pass with latest correct information

can be built with stable rust 1.26 that has impl Trait, no need to opt-in
to unstable feature (mentioned this in README)

Also removed dependency on tokio_core crate, it was needed only for Core.handle, it is used now only as dev-dependency in tests.